### PR TITLE
bugfix: disable md5 check

### DIFF
--- a/templates/driver-statefulset.yaml
+++ b/templates/driver-statefulset.yaml
@@ -35,7 +35,7 @@ spec:
           env:
             - name: LOG_LEVEL
               value: "{{ .Values.driver.logLevel }}"
-          args: ['java','-Dcosbench.tomcat.config=conf/driver-tomcat-server.xml','-server','-cp','main/*','org.eclipse.equinox.launcher.Main','-configuration','conf/.driver','-console','18089']
+          args: ['java','-Dcosbench.tomcat.config=conf/driver-tomcat-server.xml','-Dcom.amazonaws.services.s3.disableGetObjectMD5Validation=true','-server','-cp','main/*','org.eclipse.equinox.launcher.Main','-configuration','conf/.driver','-console','18089']
           resources:
 {{ toYaml .Values.driver.resources | indent 12 }}
       affinity:


### PR DESCRIPTION
bug in java md5 check causes read ops to fail (<10% success rate)